### PR TITLE
add netipds for comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ dep:
 	go mod tidy
 	go install golang.org/x/perf/cmd/benchstat@latest
 
-size: art/size.bm bart/size.bm cidrtree/size.bm critbitgo/size.bm lpmtrie/size.bm cidranger/size.bm
+size: art/size.bm bart/size.bm cidrtree/size.bm critbitgo/size.bm lpmtrie/size.bm cidranger/size.bm netipds/size.bm
 	@echo
 	@benchstat -ignore=pkg bart/size.bm   art/size.bm
 	@echo
@@ -17,8 +17,10 @@ size: art/size.bm bart/size.bm cidrtree/size.bm critbitgo/size.bm lpmtrie/size.b
 	@benchstat -ignore=pkg bart/size.bm   lpmtrie/size.bm
 	@echo
 	@benchstat -ignore=pkg bart/size.bm   cidranger/size.bm
+	@echo
+	@benchstat -ignore=pkg bart/size.bm   netipds/size.bm
 
-lpm: art/lpm.bm bart/lpm.bm cidrtree/lpm.bm critbitgo/lpm.bm lpmtrie/lpm.bm cidranger/lpm.bm
+lpm: art/lpm.bm bart/lpm.bm cidrtree/lpm.bm critbitgo/lpm.bm lpmtrie/lpm.bm cidranger/lpm.bm netipds/lpm.bm
 	@echo
 	@benchstat -ignore=pkg bart/lpm.bm   art/lpm.bm
 	@echo
@@ -29,8 +31,10 @@ lpm: art/lpm.bm bart/lpm.bm cidrtree/lpm.bm critbitgo/lpm.bm lpmtrie/lpm.bm cidr
 	@benchstat -ignore=pkg bart/lpm.bm   lpmtrie/lpm.bm
 	@echo
 	@benchstat -ignore=pkg bart/lpm.bm   cidranger/lpm.bm
+	@echo
+	@benchstat -ignore=pkg bart/lpm.bm   netipds/lpm.bm
 
-update: art/update.bm bart/update.bm cidrtree/update.bm critbitgo/update.bm lpmtrie/update.bm cidranger/update.bm
+update: art/update.bm bart/update.bm cidrtree/update.bm critbitgo/update.bm lpmtrie/update.bm cidranger/update.bm netipds/update.bm
 	@echo
 	@benchstat -ignore=pkg bart/update.bm    art/update.bm
 	@echo
@@ -41,6 +45,8 @@ update: art/update.bm bart/update.bm cidrtree/update.bm critbitgo/update.bm lpmt
 	@benchstat -ignore=pkg bart/update.bm    lpmtrie/update.bm
 	@echo
 	@benchstat -ignore=pkg bart/update.bm    cidranger/update.bm
+	@echo
+	@benchstat -ignore=pkg bart/update.bm    netipds/update.bm
 
 #
 # benchmarks for lpm
@@ -63,6 +69,9 @@ lpmtrie/lpm.bm:
 cidranger/lpm.bm:
 	cd cidranger && go test -run=XXX  -cpu=1 -count=20  -bench=Lpm -timeout=25m | tee lpm.bm
 
+netipds/lpm.bm:
+	cd netipds && go test -run=XXX  -cpu=1 -count=20  -bench=Lpm -timeout=25m | tee lpm.bm
+
 #
 # benchmarks for tree/trie sizes, deterministic -> -benchtime=1x
 #
@@ -83,6 +92,9 @@ lpmtrie/size.bm:
 
 cidranger/size.bm:
 	cd cidranger && go test -run=XXX  -cpu=1 -count=6 -bench=Size -benchtime=1x -timeout=25m | tee size.bm
+
+netipds/size.bm:
+	cd netipds && go test -run=XXX  -cpu=1 -count=6 -bench=Size -benchtime=1x -timeout=25m | tee size.bm
 
 #
 # benchmarks for insert/delete
@@ -105,3 +117,6 @@ lpmtrie/update.bm:
 
 cidranger/update.bm:
 	cd cidranger && go test -run=XXX  -cpu=1 -count=6 -bench='Insert|Delete' -timeout=25m | tee update.bm
+
+netipds/update.bm:
+	cd netipds && go test -run=XXX  -cpu=1 -count=6 -bench='Insert|Delete' -timeout=25m | tee update.bm

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ comparing benchmarks for some golang IP routing table implementations:
 	github.com/Asphaltt/lpmtrie
 	github.com/gaissmai/cidrtree
 	github.com/yl2chen/cidranger
+	github.com/aromatt/netipds
 ```
 
 The ~1_000_000 **Tier1** prefix test records (IPv4 and IPv6 routes) are from a full routing table with typical
@@ -23,7 +24,7 @@ to 1 part IPv6 prefixes, which is approximately the current ratio in the Interne
 ## make your own benchmarks
 
 ```
-  $ make dep  
+  $ make dep
   $ make -B all   # takes some time!
 ```
 

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.23.0
 
 require (
 	github.com/Asphaltt/lpmtrie v0.0.0-20220205153150-3d814250b8ab
+	github.com/aromatt/netipds v0.1.8
 	github.com/gaissmai/bart v0.17.7
 	github.com/gaissmai/cidrtree v0.5.0
 	github.com/k-sone/critbitgo v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/Asphaltt/lpmtrie v0.0.0-20220205153150-3d814250b8ab h1:hzN25CB5VzeKk3/c1fi1oT03N+5365nVOMPAxixkADY=
 github.com/Asphaltt/lpmtrie v0.0.0-20220205153150-3d814250b8ab/go.mod h1:TdNTLzn3VVXKfmHAULK5gY+h/A1gLQ8NnwLB6cSN54g=
+github.com/aromatt/netipds v0.1.8 h1:UoGFEYr8uUaZGt/3LdcEIo2C0Skg0vZBf9V+2h0Ulhk=
+github.com/aromatt/netipds v0.1.8/go.mod h1:TVWwAV/IghERh+218SzJz1DfixOswt5/BhiOAUs99Hc=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gaissmai/bart v0.17.5 h1:JTuuHqgcQmfICtM45eJyNP5l2lt2lBrv+sbqysI8BLU=

--- a/netipds/lpm_test.go
+++ b/netipds/lpm_test.go
@@ -1,0 +1,70 @@
+package main_test
+
+import (
+	"net/netip"
+	"testing"
+
+	"github.com/aromatt/netipds"
+	"local/iprbench/common"
+)
+
+func BenchmarkLpmTier1Pfxs(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		fn   func([]netip.Prefix) netip.Addr
+	}{
+		{"RandomMatchIP4", common.MatchIP4},
+		{"RandomMatchIP6", common.MatchIP6},
+		{"RandomMissIP4", common.MissIP4},
+		{"RandomMissIP6", common.MissIP6},
+	}
+
+	psb := new(netipds.PrefixSetBuilder)
+	for _, route := range tier1Routes {
+		psb.Add(route)
+	}
+	ps := psb.PrefixSet()
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			ip := bm.fn(tier1Routes)
+			pfx := netip.PrefixFrom(ip, ip.BitLen())
+			b.ResetTimer()
+			for range b.N {
+				_ = ps.Encompasses(pfx)
+			}
+		})
+	}
+}
+
+func BenchmarkLpmRandomPfxs(b *testing.B) {
+	benchmarks := []struct {
+		name string
+		fn   func([]netip.Prefix) netip.Addr
+	}{
+		{"RandomMatchIP4", common.MatchIP4},
+		{"RandomMatchIP6", common.MatchIP6},
+		{"RandomMissIP4", common.MissIP4},
+		{"RandomMissIP6", common.MissIP6},
+	}
+
+	for _, k := range []int{1_000, 10_000, 100_000} {
+		for _, bm := range benchmarks {
+
+			psb := new(netipds.PrefixSetBuilder)
+			for _, route := range randomRoutes[:k] {
+				psb.Add(route)
+			}
+			ps := psb.PrefixSet()
+
+			b.Run(common.IntMap[k]+"/"+bm.name, func(b *testing.B) {
+				ip := bm.fn(randomRoutes[:k]) // get a random matching or missing ip
+				pfx := netip.PrefixFrom(ip, ip.BitLen())
+				b.ResetTimer()
+				for range b.N {
+					_ = ps.Encompasses(pfx)
+				}
+			})
+		}
+	}
+}

--- a/netipds/setup_test.go
+++ b/netipds/setup_test.go
@@ -1,0 +1,19 @@
+package main_test
+
+import (
+	"local/iprbench/common"
+)
+
+const pfxFile = "../testdata/prefixes.txt.gz"
+
+var (
+	prng = common.Prng
+
+	tier1Routes   = common.ReadFullTableShuffled(pfxFile)
+	randomRoutes  = common.RandomPrefixes(1_000_000)
+	randomRoutes4 = common.RandomPrefixes4(1_000_000)
+	randomRoutes6 = common.RandomPrefixes6(1_000_000)
+
+	probe = tier1Routes[prng.IntN(len(tier1Routes))]
+	sink  any
+)

--- a/netipds/size_test.go
+++ b/netipds/size_test.go
@@ -1,0 +1,106 @@
+package main_test
+
+import (
+	"runtime"
+	"testing"
+
+	"local/iprbench/common"
+
+	"github.com/aromatt/netipds"
+)
+
+func BenchmarkTier1PfxSize(b *testing.B) {
+	var startMem, endMem runtime.MemStats
+
+	for _, k := range []int{1_000, 10_000, 100_000, 200_000} {
+		psb := new(netipds.PrefixSetBuilder)
+
+		runtime.GC()
+		runtime.ReadMemStats(&startMem)
+
+		b.Run(common.IntMap[k], func(b *testing.B) {
+			for range b.N {
+				for _, cidr := range tier1Routes[:k] {
+					psb.Add(cidr)
+				}
+			}
+			runtime.GC()
+			runtime.ReadMemStats(&endMem)
+
+			b.ReportMetric(float64(endMem.HeapAlloc-startMem.HeapAlloc)/(float64(k)), "bytes/route")
+			b.ReportMetric(0, "ns/op")
+		})
+	}
+}
+
+func BenchmarkRandomPfx4Size(b *testing.B) {
+	var startMem, endMem runtime.MemStats
+
+	for _, k := range []int{1_000, 10_000, 100_000, 200_000} {
+		psb := new(netipds.PrefixSetBuilder)
+
+		runtime.GC()
+		runtime.ReadMemStats(&startMem)
+
+		b.Run(common.IntMap[k], func(b *testing.B) {
+			for range b.N {
+				for _, cidr := range randomRoutes4[:k] {
+					psb.Add(cidr)
+				}
+			}
+			runtime.GC()
+			runtime.ReadMemStats(&endMem)
+
+			b.ReportMetric(float64(endMem.HeapAlloc-startMem.HeapAlloc)/(float64(k)), "bytes/route")
+			b.ReportMetric(0, "ns/op")
+		})
+	}
+}
+
+func BenchmarkRandomPfx6Size(b *testing.B) {
+	var startMem, endMem runtime.MemStats
+
+	for _, k := range []int{1_000, 10_000, 100_000, 200_000} {
+		psb := new(netipds.PrefixSetBuilder)
+
+		runtime.GC()
+		runtime.ReadMemStats(&startMem)
+
+		b.Run(common.IntMap[k], func(b *testing.B) {
+			for range b.N {
+				for _, cidr := range randomRoutes6[:k] {
+					psb.Add(cidr)
+				}
+			}
+			runtime.GC()
+			runtime.ReadMemStats(&endMem)
+
+			b.ReportMetric(float64(endMem.HeapAlloc-startMem.HeapAlloc)/(float64(k)), "bytes/route")
+			b.ReportMetric(0, "ns/op")
+		})
+	}
+}
+
+func BenchmarkRandomPfxSize(b *testing.B) {
+	var startMem, endMem runtime.MemStats
+
+	for _, k := range []int{1_000, 10_000, 100_000, 200_000} {
+		psb := new(netipds.PrefixSetBuilder)
+
+		runtime.GC()
+		runtime.ReadMemStats(&startMem)
+
+		b.Run(common.IntMap[k], func(b *testing.B) {
+			for range b.N {
+				for _, cidr := range randomRoutes[:k] {
+					psb.Add(cidr)
+				}
+			}
+			runtime.GC()
+			runtime.ReadMemStats(&endMem)
+
+			b.ReportMetric(float64(endMem.HeapAlloc-startMem.HeapAlloc)/(float64(k)), "bytes/route")
+			b.ReportMetric(0, "ns/op")
+		})
+	}
+}

--- a/netipds/update_test.go
+++ b/netipds/update_test.go
@@ -1,0 +1,58 @@
+package main_test
+
+import (
+	"runtime"
+	"testing"
+
+	"local/iprbench/common"
+
+	"github.com/aromatt/netipds"
+)
+
+func BenchmarkInsertRandomPfxs(b *testing.B) {
+	for _, k := range []int{1_000, 10_000, 100_000, 200_000} {
+		name := common.IntMap[k]
+		randomPfxs := common.RandomPrefixes(k)
+
+		b.Run(name, func(b *testing.B) {
+			psb := new(netipds.PrefixSetBuilder)
+
+			runtime.GC()
+			b.ResetTimer()
+			for range b.N {
+				for _, route := range randomPfxs {
+					psb.Add(route)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(b.Elapsed())/float64(k)/float64(b.N), "ns/route")
+			b.ReportMetric(0, "ns/op")
+		})
+	}
+}
+
+func BenchmarkDeleteRandomPfxs(b *testing.B) {
+	for _, k := range []int{1_000, 10_000, 100_000, 200_000} {
+
+		randomPfxs := common.RandomPrefixes(k)
+		name := common.IntMap[k]
+
+		b.Run(name, func(b *testing.B) {
+			psb := new(netipds.PrefixSetBuilder)
+			for _, route := range randomPfxs {
+				psb.Add(route)
+			}
+
+			runtime.GC()
+			b.ResetTimer()
+			for range b.N {
+				for _, route := range randomPfxs {
+					psb.Remove(route)
+				}
+			}
+			b.StopTimer()
+			b.ReportMetric(float64(b.Elapsed())/float64(k)/float64(b.N), "ns/route")
+			b.ReportMetric(0, "ns/op")
+		})
+	}
+}


### PR DESCRIPTION
Hi @gaissmai, I started working on [netipds](https://github.com/aromatt/netipds) in December 2023, shortly before you open-sourced bart. I stumbled upon iprbench and was very curious to find out how netipds would perform. I found that with some easy optimizations, netipds was competitive with most of the libraries compared here. It's still a work in progress, but I'd love to add it to your benchmarks!

Here are the results I got for bart vs. netipds.

```
goos: linux
goarch: amd64
cpu: AMD EPYC 7R32
                       │ bart/size.bm │           netipds/size.bm           │
                       │ bytes/route  │ bytes/route  vs base                │
Tier1PfxSize/1_000         106.9 ± 2%    100.5 ± 2%    -5.99% (p=0.002 n=6)
Tier1PfxSize/10_000        79.54 ± 0%    96.05 ± 0%   +20.76% (p=0.002 n=6)
Tier1PfxSize/100_000       35.73 ± 0%    94.33 ± 0%  +164.01% (p=0.002 n=6)
Tier1PfxSize/200_000       24.14 ± 0%    93.27 ± 0%  +286.37% (p=0.002 n=6)
RandomPfx4Size/1_000      101.60 ± 2%    99.65 ± 2%    -1.92% (p=0.002 n=6)
RandomPfx4Size/10_000      75.59 ± 0%    94.17 ± 0%   +24.58% (p=0.002 n=6)
RandomPfx4Size/100_000     81.65 ± 0%    86.53 ± 0%    +5.98% (p=0.002 n=6)
RandomPfx4Size/200_000     72.96 ± 0%    82.90 ± 0%   +13.62% (p=0.002 n=6)
RandomPfx6Size/1_000      105.80 ± 2%    99.44 ± 2%    -6.01% (p=0.002 n=6)
RandomPfx6Size/10_000      85.70 ± 0%    95.17 ± 0%   +11.05% (p=0.002 n=6)
RandomPfx6Size/100_000    106.10 ± 0%    92.67 ± 0%   -12.66% (p=0.002 n=6)
RandomPfx6Size/200_000    101.00 ± 0%    91.83 ± 0%    -9.08% (p=0.002 n=6)
RandomPfxSize/1_000       104.20 ± 2%    99.46 ± 2%    -4.55% (p=0.002 n=6)
RandomPfxSize/10_000       75.58 ± 0%    94.28 ± 0%   +24.74% (p=0.002 n=6)
RandomPfxSize/100_000      82.47 ± 0%    87.83 ± 0%    +6.50% (p=0.002 n=6)
RandomPfxSize/200_000      78.36 ± 0%    84.80 ± 0%    +8.22% (p=0.002 n=6)
geomean                    77.40         93.15        +20.35%
```

```
goos: linux
goarch: amd64
cpu: AMD EPYC 7R32
                                     │ bart/lpm.bm  │             netipds/lpm.bm              │
                                     │    sec/op    │     sec/op      vs base                 │
LpmTier1Pfxs/RandomMatchIP4            25.66n ±  7%    39.95n ±   7%   +55.68% (p=0.000 n=20)
LpmTier1Pfxs/RandomMatchIP6            23.09n ± 21%    31.46n ±  28%   +36.28% (p=0.004 n=20)
LpmTier1Pfxs/RandomMissIP4             24.43n ± 50%    52.69n ±   7%  +115.72% (p=0.000 n=20)
LpmTier1Pfxs/RandomMissIP6             5.537n ±  0%   18.205n ± 110%  +228.79% (p=0.000 n=20)
LpmRandomPfxs/1_000/RandomMatchIP4     7.361n ±  0%   44.290n ±   5%  +501.73% (p=0.000 n=20)
LpmRandomPfxs/1_000/RandomMatchIP6     15.99n ±  6%    18.97n ±   0%   +18.60% (p=0.000 n=20)
LpmRandomPfxs/1_000/RandomMissIP4      17.98n ± 36%    45.22n ±   4%  +151.43% (p=0.000 n=20)
LpmRandomPfxs/1_000/RandomMissIP6      12.67n ± 56%    21.76n ±   6%   +71.81% (p=0.000 n=20)
LpmRandomPfxs/10_000/RandomMatchIP4    21.45n ±  9%    51.73n ±  14%  +141.17% (p=0.000 n=20)
LpmRandomPfxs/10_000/RandomMatchIP6    20.54n ±  6%    24.93n ±  12%   +21.37% (p=0.003 n=20)
LpmRandomPfxs/10_000/RandomMissIP4     24.50n ±  4%    59.64n ±   1%  +143.40% (p=0.000 n=20)
LpmRandomPfxs/10_000/RandomMissIP6     20.19n ± 14%    28.07n ±   4%   +39.03% (p=0.000 n=20)
LpmRandomPfxs/100_000/RandomMatchIP4   17.65n ± 46%    27.62n ±   0%   +56.49% (p=0.000 n=20)
LpmRandomPfxs/100_000/RandomMatchIP6   16.52n ± 48%    18.23n ±  23%         ~ (p=0.409 n=20)
LpmRandomPfxs/100_000/RandomMissIP4    35.50n ±  4%    27.61n ±   0%   -22.24% (p=0.000 n=20)
LpmRandomPfxs/100_000/RandomMissIP6    26.11n ±  5%    33.65n ±   3%   +28.90% (p=0.000 n=20)
geomean                                18.05n          31.64n          +75.30%
```
```
goos: linux
goarch: amd64
cpu: AMD EPYC 7R32
                         │ bart/update.bm │           netipds/update.bm           │
                         │   sec/route    │  sec/route    vs base                 │
InsertRandomPfxs/1_000        37.39n ± 0%   180.20n ± 0%   +381.95% (p=0.002 n=6)
InsertRandomPfxs/10_000       50.37n ± 1%   266.95n ± 0%   +429.98% (p=0.002 n=6)
InsertRandomPfxs/100_000      76.38n ± 0%   365.65n ± 0%   +378.72% (p=0.002 n=6)
InsertRandomPfxs/200_000      134.4n ± 1%    450.8n ± 0%   +235.58% (p=0.002 n=6)
DeleteRandomPfxs/1_000        16.77n ± 1%   116.60n ± 1%   +595.29% (p=0.002 n=6)
DeleteRandomPfxs/10_000       16.50n ± 1%   182.05n ± 1%  +1003.33% (p=0.002 n=6)
DeleteRandomPfxs/100_000      16.33n ± 0%   288.30n ± 0%  +1666.00% (p=0.002 n=6)
DeleteRandomPfxs/200_000      16.62n ± 1%   366.75n ± 0%  +2106.68% (p=0.002 n=6)
geomean                       33.13n         254.9n        +669.29%
```