### PR TITLE
Add common.Sink and retain LPM benchmark lookup results

### DIFF
--- a/bart/lpm_test.go
+++ b/bart/lpm_test.go
@@ -30,11 +30,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyIPs := bm.fn(common.N, tier1Routes)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				rt.Contains(manyIPs[i&common.Mask])
+				ok = rt.Contains(manyIPs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -62,11 +63,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyIPs := bm.fn(common.N, randomRoutes[:k])
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					rt.Contains(manyIPs[i&common.Mask])
+					ok = rt.Contains(manyIPs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}

--- a/common/helpers.go
+++ b/common/helpers.go
@@ -15,6 +15,8 @@ import (
 	"github.com/gaissmai/extnetip"
 )
 
+var Sink any
+
 var IntMap = map[int]string{
 	1:         "1",
 	2:         "2",

--- a/critbitgo/lpm_test.go
+++ b/critbitgo/lpm_test.go
@@ -29,11 +29,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyIPs := common.AddrsToIPs(manyNetIPs)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				rt.Contains(manyIPs[i&common.Mask])
+				ok = rt.Contains(manyIPs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -62,11 +63,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyIPs := common.AddrsToIPs(manyNetIPs)
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					rt.Contains(manyIPs[i&common.Mask])
+					ok = rt.Contains(manyIPs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}

--- a/fast/lpm_test.go
+++ b/fast/lpm_test.go
@@ -30,11 +30,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyIPs := bm.fn(common.N, tier1Routes)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				rt.Contains(manyIPs[i&common.Mask])
+				ok = rt.Contains(manyIPs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -62,11 +63,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyIPs := bm.fn(common.N, randomRoutes[:k])
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					rt.Contains(manyIPs[i&common.Mask])
+					ok = rt.Contains(manyIPs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}

--- a/kentik-patricia/lpm_test.go
+++ b/kentik-patricia/lpm_test.go
@@ -28,11 +28,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyIPs := bm.fn(common.N, tier1Routes)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				rt.Lookup(manyIPs[i&common.Mask])
+				_, ok = rt.Lookup(manyIPs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -60,11 +61,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyIPs := bm.fn(common.N, randomRoutes[:k])
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					rt.Lookup(manyIPs[i&common.Mask])
+					_, ok = rt.Lookup(manyIPs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}

--- a/lite/lpm_test.go
+++ b/lite/lpm_test.go
@@ -30,11 +30,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyIPs := bm.fn(common.N, tier1Routes)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				rt.Contains(manyIPs[i&common.Mask])
+				ok = rt.Contains(manyIPs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -62,11 +63,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyIPs := bm.fn(common.N, randomRoutes[:k])
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					rt.Contains(manyIPs[i&common.Mask])
+					ok = rt.Contains(manyIPs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}

--- a/lpmtrie/lpm_test.go
+++ b/lpmtrie/lpm_test.go
@@ -29,11 +29,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyIPs := common.AddrsToIPs(manyNetIPs)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				rt.Lookup(manyIPs[i&common.Mask])
+				_, ok = rt.Lookup(manyIPs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -62,11 +63,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyIPs := common.AddrsToIPs(manyNetIPs)
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					rt.Lookup(manyIPs[i&common.Mask])
+					_, ok = rt.Lookup(manyIPs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}

--- a/netipds/lpm_test.go
+++ b/netipds/lpm_test.go
@@ -32,11 +32,12 @@ func BenchmarkLpmTier1Pfxs(b *testing.B) {
 			manyPfxs := common.AddrsToPfxs(manyIPs)
 
 			i := 0
+			ok := false
 			for b.Loop() {
-				ps.Encompasses(manyPfxs[i&common.Mask])
+				ok = ps.Encompasses(manyPfxs[i&common.Mask])
 				i++
 			}
-
+			common.Sink = ok
 		})
 	}
 }
@@ -66,11 +67,12 @@ func BenchmarkLpmRandomPfxs(b *testing.B) {
 				manyPfxs := common.AddrsToPfxs(manyIPs)
 
 				i := 0
+				ok := false
 				for b.Loop() {
-					ps.Encompasses(manyPfxs[i&common.Mask])
+					ok = ps.Encompasses(manyPfxs[i&common.Mask])
 					i++
 				}
-
+				common.Sink = ok
 			})
 		}
 	}


### PR DESCRIPTION
@coderabbit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Improved longest-prefix matching benchmark reliability by ensuring lookup and containment results are retained during benchmark runs.
  - Prevented compiler optimizations from eliminating benchmarked operations, producing more representative performance measurements across supported implementations.
  - Updated benchmark coverage for tiered-prefix and random-prefix scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->